### PR TITLE
Added the option to intellihide only for the active window

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -14,6 +14,7 @@ const TopPanel = Me.imports.topPanel;
 const Mainloop = imports.mainloop;
 
 let event_intellihide_setting=null;
+let event_activeWindow_setting=null;
 
 let settings=null;
 let intellihide=null;
@@ -25,19 +26,22 @@ function show() { panel.set_preventHide(true); }
 function hide() { panel.set_preventHide(false); }
 
 function update_intellihide_status() {
-    if(settings.get_boolean('enable-intellihide') && intellihide === null)
+    if(settings.get_boolean('enable-intellihide') && intellihide === null) {
         intellihide = new Intellihide.intellihide(show, hide, panel);
-    else {
+    } else {
         if(intellihide !== null) intellihide.destroy();
         intellihide = null;
         hide();
     }
+    if(intellihide !== null)
+        intellihide._onlyActive(settings.get_boolean('enable-active-window'));
 }
 
 function enable() {
     settings = Convenience.getSettings();
     panel = new TopPanel.topPanel(settings);
     event_intellihide_setting = settings.connect('changed::enable-intellihide', update_intellihide_status);
+    event_activeWindow_setting = settings.connect('changed::enable-active-window', update_intellihide_status);
     update_intellihide_status();
 }
 
@@ -45,6 +49,8 @@ function disable() {
     if(intellihide !== null) intellihide.destroy();
     if(event_intellihide_setting !== null) 
         settings.disconnect(event_intellihide_setting);
+    if(event_activeWindow_setting !== null)
+        settings.disconeect(event_activeWindow_setting);
     panel.destroy();
     settings.run_dispose();
     

--- a/intellihide.js
+++ b/intellihide.js
@@ -57,6 +57,9 @@ const intellihide = new Lang.Class({
         // Target object
         this._target = target;
 
+        // Set intellihide to use only the active window (or not)
+        this._activeWindow = false;
+
         // Main id of the timeout controlling timeout for updatePanelVisibility function 
         // when windows are dragged around (move and resize)
         this._windowChangedTimeout = 0;
@@ -249,6 +252,15 @@ const intellihide = new Lang.Class({
 
         var wksp = meta_win.get_workspace();
         var wksp_index = wksp.index();
+        let currentApp = this._tracker.get_window_app(meta_win);
+
+        if(this._activeWindow) {
+          if(this._focusApp != currentApp) {
+            return false;
+          } else {
+            return true;
+          }
+        }
 
         // Skip windows of other apps
         // "intellihide-perapp" option is always false
@@ -258,7 +270,7 @@ const intellihide = new Lang.Class({
             if (meta_win.get_wm_class() == 'DropDownTerminalWindow')
                 return true;
 
-            let currentApp = this._tracker.get_window_app(meta_win);
+            //let currentApp = this._tracker.get_window_app(meta_win);
 
             // But consider half maximized windows
             // Useful if one is using two apps side by side
@@ -293,6 +305,10 @@ const intellihide = new Lang.Class({
         }
         return false;
 
+    },
+
+    _onlyActive: function(active) {
+      this._activeWindow = active;
     }
 
 });

--- a/org.gnome.shell.extensions.hidetopbar.gschema.xml
+++ b/org.gnome.shell.extensions.hidetopbar.gschema.xml
@@ -86,5 +86,13 @@
         When enabled, the panel will only hide if a window takes the space.
       </description>
     </key>
+    <key name="enable-active-window" type="b">
+      <default>true</default>
+      <summary>Enable Intellihide only for active window</summary>
+      <description>
+        When enabled, the panel will only hide if the active window
+        takes the space.
+      </description>
+    </key>
   </schema>
 </schemalist>

--- a/prefs.js
+++ b/prefs.js
@@ -266,6 +266,7 @@ function buildPrefsWidget() {
     let settings_vbox = new Gtk.VBox({margin_left: 20, margin_top: 10});
     let settings_array = [
         ['enable-intellihide',_("Only hide panel when a window takes the space")],
+        ['enable-active-window',_("Only when the active window takes the space")],
     ];
     settings_array.forEach(function (s) {
         let hbox = new Gtk.HBox();


### PR DESCRIPTION
I added an option to the intellihide mechanism to only use the active window. This allows a maximized window in the background to be covered by the top bar, and also have the top bar dodge the focused window
![screenshot from 2015-02-22 16 28 34](https://cloud.githubusercontent.com/assets/11138589/6320594/3b36162c-bab0-11e4-9b60-164432b118a8.png)
![screenshot from 2015-02-22 16 29 21](https://cloud.githubusercontent.com/assets/11138589/6320607/59409584-bab0-11e4-8c08-2c0f2cd184dd.png)
![screenshot from 2015-02-22 16 30 03](https://cloud.githubusercontent.com/assets/11138589/6320608/599ad88c-bab0-11e4-9468-cf88637f09f9.png)


