### PR TITLE
Fixed typo, mistyped 'disconnect' in extension.js

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -50,7 +50,7 @@ function disable() {
     if(event_intellihide_setting !== null) 
         settings.disconnect(event_intellihide_setting);
     if(event_activeWindow_setting !== null)
-        settings.disconeect(event_activeWindow_setting);
+        settings.disconnect(event_activeWindow_setting);
     panel.destroy();
     settings.run_dispose();
     


### PR DESCRIPTION
I mistyped disconnect in extension.js, this causes errors in the extension that seem to only appear on unload... I've now tested my changes more thoroughly.