### PR TITLE
shell version 3.20 added to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["3.8","3.10","3.12","3.14","3.16","3.18"],
+  "shell-version": ["3.8","3.10","3.12","3.14","3.16","3.18","3.20"],
   "uuid": "hidetopbar@mathieu.bidon.ca",
   "name": "Hide Top Bar",
   "settings-schema": "org.gnome.shell.extensions.hidetopbar",


### PR DESCRIPTION
**First pull request! If anything could be improved in the process, let me know.**

I've encountered the same problems as @nos1609 following the steps at README.md file, but I was able to make it work with the tweak tool and a gnome session restart. After the command bellow nothing happened. I don't know if this is a problem.

`gnome-shell-extension-tool -e hidetopbar@mathieu.bidon.ca `

To get this working on gnome 3.20 I did these steps:

1. git clone https://github.com/mlutfy/hidetopbar/ (_or my forked repo_)
2. shell version 3.20 added to metadata.json
3. make schemas
4. zip repo folder
5. opened tweak tool and installed the .zip extension
6. restarted gnome session
7. enjoy it: life is good, thank you