### PR TITLE
add support gnome-shell version 3.21.91 (current in debian testing)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["3.16","3.18","3.20"],
+  "shell-version": ["3.16","3.18","3.20", "3.21.91" ],
   "uuid": "hidetopbar@mathieu.bidon.ca",
   "name": "Hide Top Bar",
   "settings-schema": "org.gnome.shell.extensions.hidetopbar",


### PR DESCRIPTION
the Gnome Shell version used in Debian testing has been added