### PR TITLE
Use var instead of let when declaring variable multiple times, fix #128.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 hidetopbar.zip
 schemas
+.idea/*
+*.iml

--- a/prefs.js
+++ b/prefs.js
@@ -17,7 +17,7 @@ function init() {
 
 function buildPrefsWidget() {
     let frame = new Gtk.VBox({border_width: 10, spacing: 6});
-    
+
 /******************************************************************************
  ************************************** Section Sensitivity *******************
  ******************************************************************************/
@@ -28,62 +28,62 @@ function buildPrefsWidget() {
         xalign: 0
     }), false, false, 0);
 
-    let settings_vbox = new Gtk.VBox({margin_left: 20, margin_top: 10, spacing: 6});
-    let settings_array = [
+    var settings_vbox = new Gtk.VBox({margin_left: 20, margin_top: 10, spacing: 6});
+    var settings_array = [
         ['mouse-sensitive',_("Show panel when mouse approaches edge of the screen")],
         ['hot-corner',_("Keep hot corner sensitive, even in hidden state")],
         ['mouse-triggers-overview',_("In the above case show overview, too")],
     ];
     settings_array.forEach(function (s) {
-        let hbox = new Gtk.HBox();
+        var hbox = new Gtk.HBox();
         let onoff = new Gtk.Switch({active: settings.get_boolean(s[0])});
-        
+
         hbox.pack_start(new Gtk.Label({
             label: s[1],
             use_markup: true,
             xalign: 0
         }), true, true, 0);
         hbox.pack_end(onoff, false, false, 0);
-        
+
         settings.connect('changed::'+s[0], function(k,b) {
             onoff.set_active(settings.get_boolean(b)); });
 
         onoff.connect('notify::active', function(w) {
             settings.set_boolean(s[0], w.active);
         });
-        
+
         settings_vbox.pack_start(hbox, false,false, 0);
     });
     frame.pack_start(settings_vbox, true, true, 0);
 
-    let settings_vbox = new Gtk.VBox({margin_left: 20, margin_bottom: 10, spacing: 6});
-    let settings_array = [
+    var settings_vbox = new Gtk.VBox({margin_left: 20, margin_bottom: 10, spacing: 6});
+    var settings_array = [
         ['pressure-threshold',_("Pressure barrier's threshold.")],
         ['pressure-timeout',_("Pressure barrier's timeout.")]
     ];
     settings_array.forEach(function (s) {
-        let hbox = new Gtk.HBox();
+        var hbox = new Gtk.HBox();
         let spin = Gtk.SpinButton.new_with_range(0,10000,1);
         spin.set_value(settings.get_int(s[0]));
-        
+
         hbox.pack_start(new Gtk.Label({
             label: s[1],
             use_markup: true,
             xalign: 0
         }), true, true, 0);
         hbox.pack_end(spin, false, false, 0);
-        
+
         settings.connect('changed::'+s[0], function(k,b) {
             spin.set_value(settings.get_int(b)); });
 
         spin.connect('value-changed', function(w) {
             settings.set_int(s[0], w.get_value());
         });
-        
+
         settings_vbox.pack_start(hbox, false,false, 0);
     });
     frame.pack_start(settings_vbox, true, true, 0);
-    
+
 /******************************************************************************
  ************************************** Section Animation *********************
  ******************************************************************************/
@@ -94,34 +94,34 @@ function buildPrefsWidget() {
         xalign: 0
     }), false, false, 0);
 
-    let settings_vbox = new Gtk.VBox({margin_left: 20, margin_top: 10, margin_bottom: 10, spacing: 6});
-    let settings_array = [
+    var settings_vbox = new Gtk.VBox({margin_left: 20, margin_top: 10, margin_bottom: 10, spacing: 6});
+    var settings_array = [
         ['animation-time-overview',_("Slide animation time when entering/leaving overview.")],
         ['animation-time-autohide',_("Slide animation time when mouse approaches edge of the screen.")]
     ];
     settings_array.forEach(function (s) {
-        let hbox = new Gtk.HBox();
+        var hbox = new Gtk.HBox();
         let spin = Gtk.SpinButton.new_with_range(0.0,1.0,0.1);
         spin.set_value(settings.get_double(s[0]));
-        
+
         hbox.pack_start(new Gtk.Label({
             label: s[1],
             use_markup: true,
             xalign: 0
         }), true, true, 0);
         hbox.pack_end(spin, false, false, 0);
-        
+
         settings.connect('changed::'+s[0], function(k,b) {
             spin.set_value(settings.get_double(b)); });
 
         spin.connect('value-changed', function(w) {
             settings.set_double(s[0], w.get_value());
         });
-        
+
         settings_vbox.pack_start(hbox, false,false, 0);
     });
     frame.pack_start(settings_vbox, true, true, 0);
-    
+
 /******************************************************************************
  ************************************** Section Shortcuts *********************
  ******************************************************************************/
@@ -132,11 +132,11 @@ function buildPrefsWidget() {
         xalign: 0
     }), false, false, 0);
 
-    let settings_vbox = new Gtk.VBox({margin_left: 20, margin_top: 10, spacing: 6});
-    
+    var settings_vbox = new Gtk.VBox({margin_left: 20, margin_top: 10, spacing: 6});
+
 /* ++++++++++++++++++++++++++++++++++++ Keyboard accelerator +++++ */
 
-    let hbox = new Gtk.HBox();
+    var hbox = new Gtk.HBox();
     let model = new Gtk.ListStore();
 
     model.set_column_types([
@@ -181,7 +181,7 @@ function buildPrefsWidget() {
         model.set(iterator, [0, 1], [0, 0]);
         settings.set_strv('shortcut-keybind', []);
     });
-    
+
     let col = new Gtk.TreeViewColumn({ min_width: 200 });
 
     col.pack_end(cellrend, false);
@@ -189,24 +189,24 @@ function buildPrefsWidget() {
     col.add_attribute(cellrend, 'accel-key', 1);
     treeview.append_column(col);
     treeview.set_headers_visible(false);
-    
+
     hbox.pack_start(new Gtk.Label({
         label: _("Key that triggers the bar to be shown."),
         use_markup: true,
         xalign: 0
     }), true, true, 0);
     hbox.pack_end(treeview, false, true, 0);
-        
+
     settings.connect('changed::shortcut-keybind', function(k, b) {
         let row = model.get(0);
-        model.set(row, [0, 1], settings.get_strv(b)); 
+        model.set(row, [0, 1], settings.get_strv(b));
     });
-    
+
     settings_vbox.pack_start(hbox, false, false, 3);
-    
+
 /* ++++++++++++++++++++++++++++++++++++ End: Keyboard accelerator +++++ */
 
-    let hbox = new Gtk.HBox();
+    var hbox = new Gtk.HBox();
 
     let spin = Gtk.SpinButton.new_with_range(0.0,10.0,0.1);
     spin.set_value(settings.get_double('shortcut-delay'));
@@ -217,9 +217,9 @@ function buildPrefsWidget() {
         xalign: 0
     }), true, true, 0);
     hbox.pack_end(spin, false, false, 0);
-        
+
     settings.connect('changed::shortcut-delay', function(k,b) {
-        spin.set_value(settings.get_double(b)); 
+        spin.set_value(settings.get_double(b));
     });
     spin.connect('value-changed', function(w) {
         settings.set_double('shortcut-delay', w.get_value());
@@ -227,11 +227,11 @@ function buildPrefsWidget() {
 
     settings_vbox.pack_start(hbox, false,false, 0);
 
-    let settings_array = [
+    var settings_array = [
         ['shortcut-toggles',_("Pressing the shortcut again rehides the panel.")],
     ];
     settings_array.forEach(function (s) {
-        let hbox = new Gtk.HBox();
+        var hbox = new Gtk.HBox();
         let onoff = new Gtk.Switch({active: settings.get_boolean(s[0])});
 
         hbox.pack_start(new Gtk.Label({
@@ -252,7 +252,7 @@ function buildPrefsWidget() {
     });
 
     frame.pack_start(settings_vbox, true, true, 0);
-    
+
 /******************************************************************************
  ************************************** Section Intellihide *******************
  ******************************************************************************/
@@ -263,13 +263,13 @@ function buildPrefsWidget() {
         xalign: 0
     }), false, false, 0);
 
-    let settings_vbox = new Gtk.VBox({margin_left: 20, margin_top: 10, spacing: 6});
-    let settings_array = [
+    var settings_vbox = new Gtk.VBox({margin_left: 20, margin_top: 10, spacing: 6});
+    var settings_array = [
         ['enable-intellihide',_("Only hide panel when a window takes the space")],
         ['enable-active-window',_("Only when the active window takes the space")],
     ];
     settings_array.forEach(function (s) {
-        let hbox = new Gtk.HBox();
+        var hbox = new Gtk.HBox();
         let onoff = new Gtk.Switch({active: settings.get_boolean(s[0])});
 
         hbox.pack_start(new Gtk.Label({
@@ -285,7 +285,7 @@ function buildPrefsWidget() {
         onoff.connect('notify::active', function(w) {
             settings.set_boolean(s[0], w.active);
         });
-        
+
         settings_vbox.pack_start(hbox, false,false, 0);
     });
     frame.pack_start(settings_vbox, true, true, 0);


### PR DESCRIPTION
This is a fix for #128, I encountered the same issue when installing in GNOME 3.24. Let cannot be declared multiple times. I think this is due to changes as a result of the upgrade to Spidermonkey 38 [1] and ES6 [2].

[1] https://help.gnome.org/misc/release-notes/3.24/developers.html.en
[2] https://stackoverflow.com/questions/36398258/typeerror-redeclaration-of-let-error-in-firebug-console-if-running-es6-code