### PR TITLE
fix #113 multimonitor issue

### DIFF
--- a/panelVisibilityManager.js
+++ b/panelVisibilityManager.js
@@ -253,13 +253,22 @@ const PanelVisibilityManager = new Lang.Class({
     },
 
     _updateHotCorner: function(panel_hidden) {
-        let HotCorner = Main.layoutManager.hotCorners[0];
-        if(!panel_hidden || this._settings.get_boolean('hot-corner')) {
-            HotCorner.setBarrierSize(PanelBox.height);
-        } else {
-            Mainloop.timeout_add(100, function () {
-                HotCorner.setBarrierSize(0)
-            });
+        let HotCorner = null;
+        for(var i = 0; i < Main.layoutManager.hotCorners.length; i++){
+          let hc = Main.layoutManager.hotCorners[i];
+          if(hc){
+            let HotCorner = hc;
+            break;
+          }
+        }
+        if(HotCorner){
+          if(!panel_hidden || this._settings.get_boolean('hot-corner')) {
+              HotCorner.setBarrierSize(PanelBox.height);
+          } else {
+              Mainloop.timeout_add(100, function () {
+                  HotCorner.setBarrierSize(0)
+              });
+          }
         }
     },
 

--- a/panelVisibilityManager.js
+++ b/panelVisibilityManager.js
@@ -257,7 +257,7 @@ const PanelVisibilityManager = new Lang.Class({
         for(var i = 0; i < Main.layoutManager.hotCorners.length; i++){
           let hc = Main.layoutManager.hotCorners[i];
           if(hc){
-            let HotCorner = hc;
+            HotCorner = hc;
             break;
           }
         }


### PR DESCRIPTION
fixes #113 
Never used javascript before, but it seems to work.
On multimonitor displays there's null entries in the hotCorners array, this just tries to find the first non-null entry. Single monitor displays shouldn't see a difference.