### PR TITLE
Update readme to suggest installing from gnome.org via FireFox

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ You can also manage extensions from https://extensions.gnome.org/local/
 Installing from gnome.org:
 --------------------------
 
-If you install this extension via https://extensions.gnome.org/extension/545/hide-top-bar/,
-make sure that you install the extension with FireFox. It may not work with Chrome.
+You can install the extension directly from [gnome.org/.../hide-top-bar/](https://extensions.gnome.org/extension/545/hide-top-bar/).
+
+If you're installing via a Chrome browser, make sure you read the [GNOME Shell integration for Chrome Installation Guide](https://wiki.gnome.org/Projects/GnomeShellIntegrationForChrome/Installation).
 
 License:
 --------

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Hides Gnome's topbar except in overview mode.
 Maintained by Thomas Vogt.
 With contributions by Philip Witte and Mathieu Lutfy.
 
-Installation:
--------------
+Local installation:
+-------------------
 
 Compile the gsettings schema by running
 
@@ -31,6 +31,12 @@ Install this in your extensions directory
 The last commandline restarts GNOME Shell.
 
 You can also manage extensions from https://extensions.gnome.org/local/
+
+Installing from gnome.org:
+--------------------------
+
+If you install this extension via https://extensions.gnome.org/extension/545/hide-top-bar/,
+make sure that you install the extension with FireFox. It may not work with Chrome.
 
 License:
 --------

--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ You can also manage extensions from https://extensions.gnome.org/local/
 Installing from gnome.org:
 --------------------------
 
-You can install the extension directly from [gnome.org/.../hide-top-bar/](https://extensions.gnome.org/extension/545/hide-top-bar/).
+You can install the extension directly from
+[gnome.org/.../hide-top-bar/](https://extensions.gnome.org/extension/545/hide-top-bar/).
 
-If you're installing via a Chrome browser, make sure you read the [GNOME Shell integration for Chrome Installation Guide](https://wiki.gnome.org/Projects/GnomeShellIntegrationForChrome/Installation).
+If you're installing via a Chrome browser, make sure you read the
+[GNOME Shell integration for Chrome Installation
+Guide](https://wiki.gnome.org/Projects/GnomeShellIntegrationForChrome/Installation).
 
 License:
 --------


### PR DESCRIPTION
### What

If you try install the extension via gnome.org in Google Chrome, the installation will fail with an error. The readme will now advice you to use FireFox to install the extension.

### Issue

https://github.com/mlutfy/hidetopbar/issues/138