### PR TITLE
Declare compatible to shell version 3.26

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["3.18","3.20","3.22","3.24"],
+  "shell-version": ["3.18","3.20","3.22","3.24","3.26"],
   "uuid": "hidetopbar@mathieu.bidon.ca",
   "name": "Hide Top Bar",
   "settings-schema": "org.gnome.shell.extensions.hidetopbar",


### PR DESCRIPTION
I am using hidetopbar with GNOME Shell 3.26 on Arch Linux since a few weeks. As far as I can tell, it does its job as well as it did before the version bump, both with Wayland and Xorg. So I herewith suggest to increase the compatible version range.