### PR TITLE
It resolves #137 issue, notifications display correct now

### DIFF
--- a/intellihide.js
+++ b/intellihide.js
@@ -254,17 +254,6 @@ const intellihide = new Lang.Class({
             }
         }
 
-        // Check if notification banner overlaps
-        if(Main.messageTray.actor.visible) {
-            let rect = Main.messageTray.actor.get_allocation_box(),
-                test = ( rect.x1 < this._targetBox.x2) &&
-                       ( rect.x2 > this._targetBox.x1 ) &&
-                       ( rect.y1 < this._targetBox.y2 ) &&
-                       ( rect.y2 > this._targetBox.y1 );
-
-            if(test) overlaps = OverlapStatus.TRUE;
-        }
-
         if ( this._status !== overlaps ) {
             this._status = overlaps;
             this.emit('status-changed', this._status);


### PR DESCRIPTION
Implemented two notification positions which depends on top bar visibility.
Hidden: It displays without offset, as before
![image](https://user-images.githubusercontent.com/6323370/32980863-49742614-cc7f-11e7-8e7c-10a9f217a760.png)
Visible: It displays under the panel
![image](https://user-images.githubusercontent.com/6323370/32980867-5ee6aa08-cc7f-11e7-9487-d683a439ed0c.png)
It works great for native and custom Panel OSD positions.