### PR TITLE
Add support for 3.28.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["3.18","3.20","3.22","3.24","3.26"],
+  "shell-version": ["3.18","3.20","3.22","3.24","3.26","3.28"],
   "uuid": "hidetopbar@mathieu.bidon.ca",
   "name": "Hide Top Bar",
   "settings-schema": "org.gnome.shell.extensions.hidetopbar",


### PR DESCRIPTION
Works fine on GNOME Shell 3.28.3