### PR TITLE
add option to show topbar when a fullscreen window is active

### DIFF
--- a/org.gnome.shell.extensions.hidetopbar.gschema.xml
+++ b/org.gnome.shell.extensions.hidetopbar.gschema.xml
@@ -17,6 +17,13 @@
         approaches the edge of the screen.
       </description>
     </key>
+    <key name="mouse-sensitive-fullscreen-window" type="b">
+      <default>true</default>
+      <summary>Also show panel when mouse approaches edge of the screen when fullscreen.</summary>
+      <description>
+        Set to "true" to also show panel when mouse approaches edge of the screen when windows are in fullscreen mode.
+      </description>
+    </key>
     <key name="mouse-triggers-overview" type="b">
       <default>false</default>
       <summary>Show overview when mouse approaches edge of the screen</summary>

--- a/panelVisibilityManager.js
+++ b/panelVisibilityManager.js
@@ -229,8 +229,9 @@ var PanelVisibilityManager = new Lang.Class({
         this._panelPressure.connect(
             'trigger',
             Lang.bind(this, function(barrier) {
-                if (Main.layoutManager.primaryMonitor.inFullscreen)
+                if ( (Main.layoutManager.primaryMonitor.inFullscreen) && (!this._settings.get_boolean('mouse-sensitive-fullscreen-window')) ) {
                     return;
+                }
                 this.show(
                     this._settings.get_double('animation-time-autohide'),
                     "mouse-enter"

--- a/prefs.js
+++ b/prefs.js
@@ -44,6 +44,7 @@ function buildPrefsWidget() {
     settings_vbox = new Gtk.VBox({margin_left: 20, margin_top: 10, spacing: 6});
     settings_array = [
         ['mouse-sensitive',_("Show panel when mouse approaches edge of the screen")],
+        ['mouse-sensitive-fullscreen-window',_("In the above case, also show panel when fullscreen.")],
         ['hot-corner',_("Keep hot corner sensitive, even in hidden state")],
         ['mouse-triggers-overview',_("In the above case show overview, too")],
     ];


### PR DESCRIPTION
Added an option in the settings panel to also show the topbar when hitting the edge when in fullscreen mode (or a fullscreen window is in the background).

Related to #157

The box I added to the settings (`mouse-sensitive-fullscreen-window`) should ideally be linked to the  `mouse-sensitive` option: the former should be disabled (or greyed out) whenever the latter is disabled