### PR TITLE
Fix: Bar doesn't rehide on slow mouse-out #147

### DIFF
--- a/panelVisibilityManager.js
+++ b/panelVisibilityManager.js
@@ -75,9 +75,9 @@ var PanelVisibilityManager = new Lang.Class({
         if(anchor_y < 0) delta_y = -delta_y;
         let mouse = global.get_pointer(),
             mouse_is_over = (mouse[1] >= this._staticBox.y1 &&
-                                 mouse[1] <= this._staticBox.y2 &&
+                                 mouse[1] < this._staticBox.y2 &&
                                  mouse[0] >= this._staticBox.x1 &&
-                                 mouse[0] <= this._staticBox.x2);
+                                 mouse[0] < this._staticBox.x2);
         if(trigger == "mouse-left" && mouse_is_over) return;
 
         if(this._tweenActive) {


### PR DESCRIPTION
If the top bar is eg. 34 pixels high the  _staticBox y coordinates will be 0.0 to 34.0 but the mouse pointer coordinates when over the bar are 0 to 33 so the larger number needs to be **less than** rather than **less than or equal**.  The same goes for the x direction.

This fixes Issue #147

Moving the mouse very slowly ensures gnome will send the mouse out event on the single offending pixel ensuring the bug occurs every time.