### PR TITLE
Mention Debian package as alternative installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ If you're installing via a Chrome browser, make sure you read the
 [GNOME Shell integration for Chrome Installation
 Guide](https://wiki.gnome.org/Projects/GnomeShellIntegrationForChrome/Installation).
 
+
+[Debian](https://packages.debian.org/unstable/gnome-shell-extension-autohidetopbar)/[Ubuntu](https://launchpad.net/ubuntu/+source/gnome-shell-extension-autohidetopbar)
+---------------
+
+If you are using a Debian based distribution, the preferred installation method is to use 
+the packaged version. By this, problems by incompatibilites caused by different gnome-shell versions in
+your distribution can be avoided. You can install the package with:
+
+    sudo apt install gnome-shell-extension-autohidetopbar
+
+If you find problems with the _Debian packaged version_, please file bugs at the [Debian Bugtracking system](https://www.debian.org/Bugs/Reporting).
+
 Local installation:
 -------------------
 


### PR DESCRIPTION
As this seems to pop up regularily, (#235, #234, #214 …), maybe it would be a good idea to hint the people to use the Debian package whenever possible.

 (\me as theDebian package maintainer tries hard to ensure that the version in Debian is compatible with the gnome version, so I hope this would reduce the number of bugs filed caused by distributions…)

BTW, Many thanks for you extension! I love it and apparently Debian users, too: (https://qa.debian.org/popcon.php?package=gnome-shell-extension-autohidetopbar)