### PR TITLE
Uniformize punctuation of settings options

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -62,7 +62,7 @@ function buildPrefsWidget() {
     settings_vbox = new Gtk.VBox({margin_left: 20, margin_top: 10, spacing: 6});
     settings_array = [
         ['mouse-sensitive',_("Show panel when mouse approaches edge of the screen")],
-        ['mouse-sensitive-fullscreen-window',_("In the above case, also show panel when fullscreen.")],
+        ['mouse-sensitive-fullscreen-window',_("In the above case, also show panel when fullscreen")],
         ['hot-corner',_("Keep hot corner sensitive, even in hidden state")],
         ['mouse-triggers-overview',_("In the above case show overview, too")],
     ];
@@ -89,8 +89,8 @@ function buildPrefsWidget() {
 
     settings_vbox = new Gtk.VBox({margin_left: 20, margin_bottom: 10, spacing: 6});
     settings_array = [
-        ['pressure-threshold',_("Pressure barrier's threshold.")],
-        ['pressure-timeout',_("Pressure barrier's timeout.")]
+        ['pressure-threshold',_("Pressure barrier's threshold:")],
+        ['pressure-timeout',_("Pressure barrier's timeout:")]
     ];
     settings_array.forEach(function (s) {
         settings_spin = Gtk.SpinButton.new_with_range(0,10000,1);
@@ -126,8 +126,8 @@ function buildPrefsWidget() {
 
     settings_vbox = new Gtk.VBox({margin_left: 20, margin_top: 10, margin_bottom: 10, spacing: 6});
     settings_array = [
-        ['animation-time-overview',_("Slide animation time when entering/leaving overview.")],
-        ['animation-time-autohide',_("Slide animation time when mouse approaches edge of the screen.")]
+        ['animation-time-overview',_("Slide animation time when entering/leaving overview:")],
+        ['animation-time-autohide',_("Slide animation time when mouse approaches edge of the screen:")]
     ];
     settings_array.forEach(function (s) {
         settings_spin = Gtk.SpinButton.new_with_range(0.0,1.0,0.1);
@@ -218,7 +218,7 @@ function buildPrefsWidget() {
     treeview.set_headers_visible(false);
 
     settings_hbox.pack_start(new Gtk.Label({
-        label: _("Key that triggers the bar to be shown."),
+        label: _("Key that triggers the bar to be shown:"),
         use_markup: true,
         xalign: 0
     }), true, true, 0);
@@ -238,7 +238,7 @@ function buildPrefsWidget() {
 
     settings_hbox = new Gtk.HBox();
     settings_hbox.pack_start(new Gtk.Label({
-        label: _("Delay before the bar rehides after key press."),
+        label: _("Delay before the bar rehides after key press:"),
         use_markup: true,
         xalign: 0
     }), true, true, 0);
@@ -254,7 +254,7 @@ function buildPrefsWidget() {
     settings_vbox.pack_start(settings_hbox, false,false, 0);
 
     settings_array = [
-        ['shortcut-toggles',_("Pressing the shortcut again rehides the panel.")],
+        ['shortcut-toggles',_("Pressing the shortcut again rehides the panel")],
     ];
     settings_array.forEach(function (s) {
         settings_onoff = new Gtk.Switch({active: settings.get_boolean(s[0])});


### PR DESCRIPTION
Here is a suggestion regarding punctuation in the end of the options' description in preferences panel. Some had full-stop, others haven't. My suggestion is:
- For Switch descriptions, end **without** a full-stop (`.`) which AFAIK is what is normally found in descriptions of checkboxes and switches
- For SpinButton descriptions, end with colon (`:`) to indicate that the description is for that value (e.g. 'Pressure barrier's threshold: 100')