### PR TITLE
replace references to allocation-changed with notify::allocation (fixes #255)

### DIFF
--- a/intellihide.js
+++ b/intellihide.js
@@ -159,7 +159,7 @@ var Intellihide = class HideTopBar_Intellihide {
     _addWindowSignals(wa) {
         if (!this._handledWindow(wa))
             return;
-        let signalId = wa.connect('allocation-changed', this._checkOverlap.bind(this));
+        let signalId = wa.connect('notify::allocation', this._checkOverlap.bind(this));
         this._trackedWindows.set(wa, signalId);
         wa.connect('destroy', this._removeWindowSignals.bind(this));
     }

--- a/panelVisibilityManager.js
+++ b/panelVisibilityManager.js
@@ -38,9 +38,8 @@ function reallocateTopIcons() {
     // Dirty hack for TopIcons compatibility:
     // triggers reallocation of ClickProxy in TopIcons
     Main.panel._rightBox.emit(
-        "allocation-changed",
-        Main.panel._rightBox.get_allocation_box(),
-        null
+        "notify::allocation",
+        Main.panel._rightBox.get_allocation_box()
     );
 }
 


### PR DESCRIPTION
Replace references to `allocation-changed` signal with references to `notify::allocation` as per the notes from this [merge request](https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1245/diffs?commit_id=787d9a5a150f25c659e20df4637b974b565c95e9).

Fixes `allocation-changed` errors in log for GNOME 3.38.