### PR TITLE
Feature hide always

### DIFF
--- a/panelVisibilityManager.js
+++ b/panelVisibilityManager.js
@@ -302,7 +302,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     }
     
     _updateSettingsHideAlways() {
-        this._hideAlways = (this._settings.get_boolean('show-in-overview') ? false : true);
+        this._hideAlways = (this._settings.get_boolean('show-in-overview')) ? false : true;
     }
 
     _updateIntellihideStatus() {

--- a/panelVisibilityManager.js
+++ b/panelVisibilityManager.js
@@ -41,7 +41,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
         this._base_y = PanelBox.y;
         this._settings = settings;
         this._preventHide = false;
-        this._hideAlways = false;
+        this._showInOverview = true;
         this._intellihideBlock = false;
         this._staticBox = new Clutter.ActorBox();
         this._animationActive = false;
@@ -65,7 +65,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
         // Load settings
         this._bindSettingsChanges();
         this._updateSettingsMouseSensitive();
-        this._updateSettingsHideAlways();
+        this._updateSettingsShowInOverview();
         this._intellihide = new Intellihide.Intellihide(this._settings, this._monitorIndex);
 
         this._updateHotCorner(false);
@@ -302,8 +302,8 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
         } else this._disablePressureBarrier();
     }
     
-    _updateSettingsHideAlways() {
-        this._hideAlways = (this._settings.get_boolean('show-in-overview')) ? false : true;
+    _updateSettingsShowInOverview() {
+        this._showInOverview = this._settings.get_boolean('show-in-overview');
     }
 
     _updateIntellihideStatus() {
@@ -343,7 +343,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
                 Main.overview,
                 'showing',
                 () => {
-                    if(!this._hideAlways) {
+                    if(this._showInOverview) {
                         this.show(
                             this._settings.get_double('animation-time-overview'),
                             "showing-overview"
@@ -425,7 +425,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
             [ 
                 this._settings,
                 'changed::show-in-overview',
-                this._updateSettingsHideAlways.bind(this)
+                this._updateSettingsShowInOverview.bind(this)
             ],
             [
                 this._settings,

--- a/panelVisibilityManager.js
+++ b/panelVisibilityManager.js
@@ -41,6 +41,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
         this._base_y = PanelBox.y;
         this._settings = settings;
         this._preventHide = false;
+        this._hideAlways = false;
         this._intellihideBlock = false;
         this._staticBox = new Clutter.ActorBox();
         this._animationActive = false;
@@ -299,6 +300,10 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
             this._initPressureBarrier();
         } else this._disablePressureBarrier();
     }
+    
+    _updateSettingsHideAlways() {
+        this._hideAlways = (this._settings.get_boolean('show-in-overview') ? false : true);
+    }
 
     _updateIntellihideStatus() {
         if(this._settings.get_boolean('enable-intellihide')) {
@@ -337,10 +342,12 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
                 Main.overview,
                 'showing',
                 () => {
-                    this.show(
-                        this._settings.get_double('animation-time-overview'),
-                        "showing-overview"
-                    );
+                    if(!_hideAlways) {
+                        this.show(
+                            this._settings.get_double('animation-time-overview'),
+                            "showing-overview"
+                        );
+                    }
                 }
             ],
             [
@@ -413,6 +420,11 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
                 this._settings,
                 'changed::pressure-threshold',
                 this._updateSettingsMouseSensitive.bind(this)
+            ],
+            [ 
+                this._settings,
+                'changed::show-in-overview',
+                this._updateSettingsHideAlways.bind(this)
             ],
             [
                 this._settings,

--- a/panelVisibilityManager.js
+++ b/panelVisibilityManager.js
@@ -65,6 +65,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
         // Load settings
         this._bindSettingsChanges();
         this._updateSettingsMouseSensitive();
+        this._updateSettingsHideAlways();
         this._intellihide = new Intellihide.Intellihide(this._settings, this._monitorIndex);
 
         this._updateHotCorner(false);
@@ -342,7 +343,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
                 Main.overview,
                 'showing',
                 () => {
-                    if(!_hideAlways) {
+                    if(!this._hideAlways) {
                         this.show(
                             this._settings.get_double('animation-time-overview'),
                             "showing-overview"

--- a/prefs.js
+++ b/prefs.js
@@ -63,6 +63,7 @@ function buildPrefsWidget() {
     settings_array = [
         ['mouse-sensitive',_("Show panel when mouse approaches edge of the screen")],
         ['mouse-sensitive-fullscreen-window',_("In the above case, also show panel when fullscreen")],
+        ['show-in-overview',_("Show panel in overview")],
         ['hot-corner',_("Keep hot corner sensitive, even in hidden state")],
         ['mouse-triggers-overview',_("In the above case show overview, too")],
     ];

--- a/schemas/org.gnome.shell.extensions.hidetopbar.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.hidetopbar.gschema.xml
@@ -101,5 +101,12 @@
         takes the space.
       </description>
     </key>
+    <key name="show-in-overview" type="b">
+      <default>true</default>
+      <summary>Show panel in overview</summary>
+      <description>
+        When enabled, the panel will be visible in overview.
+      </description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
This pull request adds support for hiding Main.layoutManager.panelBox all of the time without interfering with default logic of the shell extension. 

Related to issue #164 