### PR TITLE
Avoid top bar to overlay search bar in GNOME 40

### DIFF
--- a/panelVisibilityManager.js
+++ b/panelVisibilityManager.js
@@ -453,6 +453,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
         this._signalsHandler.destroy();
         Main.wm.removeKeybinding("shortcut-keybind");
         this._disablePressureBarrier();
+        _searchEntryBin.style = null;
 
         MessageTray._tween = this._oldTween;
         this.show(0, "destroy");

--- a/panelVisibilityManager.js
+++ b/panelVisibilityManager.js
@@ -306,7 +306,7 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     _updateSettingsShowInOverview() {
         this._showInOverview = this._settings.get_boolean('show-in-overview');
         if (this._showInOverview) {
-            _searchEntryBin.set_style("margin-top: 24px;");
+            _searchEntryBin.set_style(`margin-top: ${PanelBox.height}px;`);
         } else {
             _searchEntryBin.style = null;
         }

--- a/panelVisibilityManager.js
+++ b/panelVisibilityManager.js
@@ -33,6 +33,7 @@ const DEBUG = Convenience.DEBUG;
 const MessageTray = Main.messageTray;
 const PanelBox = Main.layoutManager.panelBox;
 const ShellActionMode = (Shell.ActionMode)?Shell.ActionMode:Shell.KeyBindingMode;
+const _searchEntryBin = Main.overview._overview._controls._searchEntryBin;
 
 var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
 
@@ -304,6 +305,11 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     
     _updateSettingsShowInOverview() {
         this._showInOverview = this._settings.get_boolean('show-in-overview');
+        if (this._showInOverview) {
+            _searchEntryBin.set_style("margin-top: 24px;");
+        } else {
+            _searchEntryBin.style = null;
+        }
     }
 
     _updateIntellihideStatus() {


### PR DESCRIPTION
This PR fixes #283 by adding a margin on the top of `Main.overview._overview._controls._searchEntryBin`, if and only if the option `show-in-overview` is enabled.