### PR TITLE
Update String and German translation

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -61,7 +61,7 @@
             <property name="can-focus">False</property>
             <property name="halign">start</property>
             <property name="hexpand">True</property>
-            <property name="label" translatable="yes">Show panel when mouse approaches edge of the screen</property>
+            <property name="label" translatable="yes">Show panel when mouse approaches top edge of the screen</property>
           </object>
           <packing>
             <property name="left-attach">0</property>
@@ -397,7 +397,7 @@
             <child>
               <object class="GtkTreeViewColumn">
                 <property name="min-width">200</property>
-                <property name="title" translatable="no">column</property>
+                <property name="title">column</property>
                 <property name="sort-column-id">0</property>
                 <child>
                   <object class="GtkCellRendererAccel" id="accel_shortcut_keybind">

--- a/locale/de/LC_MESSAGES/hidetopbar.po
+++ b/locale/de/LC_MESSAGES/hidetopbar.po
@@ -8,122 +8,118 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hidetopbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-20 01:01+0200\n"
-"PO-Revision-Date: 2020-09-20 01:07+0200\n"
-"Last-Translator: Vinzenz Vietzke <vinz@vinzv.de>\n"
+"POT-Creation-Date: 2021-09-14 11:47+0200\n"
+"PO-Revision-Date: 2021-09-14 11:49+0200\n"
+"Last-Translator: Philipp Kiemle <philipp.kiemle@gmail.com>\n"
 "Language-Team: German <>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.4.1\n"
+"X-Generator: Poedit 3.0\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: prefs.js:39 prefs.js:57
-msgid "Sensitivity"
-msgstr "Berührungsempfindlichkeit"
-
-#: prefs.js:46 prefs.js:64
+#: Settings.ui.h:1
 msgid "Show panel when mouse approaches edge of the screen"
 msgstr "Panel anzeigen, wenn die Maus den oberen Bildschirmrand berührt"
 
-#: prefs.js:47
-msgid "In the above case, also show panel when fullscreen."
-msgstr "In diesem Fall auch das Panel im Vollbildmodus aneigen."
+#: Settings.ui.h:2
+msgid "In the above case, also show panel when fullscreen"
+msgstr "In obigem Fall das Panel auch im Vollbildmodus anzeigen"
 
 #: Settings.ui.h:3
 msgid "Show panel in overview"
 msgstr "Panel in der Übersicht anzeigen"
 
-#: prefs.js:48 prefs.js:66
+#: Settings.ui.h:4
 msgid "Keep hot corner sensitive, even in hidden state"
-msgstr "\"Hot Corner\" auch aktiviert lassen, wenn das Panel versteckt ist"
+msgstr "Funktionale Ecke aktiviert lassen, selbst wenn das Panel versteckt ist"
 
-#: prefs.js:49 prefs.js:67
+#: Settings.ui.h:5
 msgid "In the above case show overview, too"
-msgstr "Wechsle im obigen Fall in die Übersicht"
+msgstr "In obigem Fall auch in die Übersicht wechseln"
 
-#: prefs.js:74
-msgid "Pressure barrier's threshold."
-msgstr "Schwellenwert der Druckempfindlichkeit."
-
-#: prefs.js:75
-msgid "Pressure barrier's timeout."
-msgstr "Time-Out der Druckempfindlichkeit."
-
-#: prefs.js:104 prefs.js:122
-msgid "Animation"
-msgstr "Animation"
-
-#: prefs.js:111
-msgid "Slide animation time when entering/leaving overview."
-msgstr "Animationszeit beim Betreten/Verlassen der Übersicht."
-
-#: prefs.js:112
-msgid "Slide animation time when mouse approaches edge of the screen."
-msgstr "Animationszeit, wenn die Maus den Bildschirmrand berührt."
-
-#: prefs.js:141 prefs.js:159
-msgid "Keyboard shortcuts"
-msgstr "Tastaturkürzel"
-
-#: prefs.js:203
-msgid "Key that triggers the bar to be shown."
-msgstr "Taste um die Leiste anzuzeigen."
-
-#: prefs.js:223
-msgid "Delay before the bar rehides after key press."
-msgstr ""
-"Verzögerung, nachdem die Leiste nach dem Drücken der Taste, wieder "
-"ausgeblendet wird."
-
-#: prefs.js:239
-msgid "Pressing the shortcut again rehides the panel."
-msgstr "Erneutes Drücken des Tastenkürzels versteckt die Leiste wieder."
-
-#: prefs.js:268 prefs.js:286
-msgid "Intellihide"
-msgstr "Intelligentes Ausblenden"
-
-#: prefs.js:275 prefs.js:293
-msgid "Only hide panel when a window takes the space"
-msgstr "Panel nur verstecken, wenn Fenster im Weg ist"
-
-#: prefs.js:276 prefs.js:294
-msgid "Only when the active window takes the space"
-msgstr "Nur wenn ein aktives Fenster im Weg ist"
-
-#: prefs.js:65
-msgid "In the above case, also show panel when fullscreen"
-msgstr "In diesem Fall auch Panel im Vollbildmodus anzeigen"
-
-#: prefs.js:92
+#: Settings.ui.h:6
 msgid "Pressure barrier's threshold:"
 msgstr "Schwellenwert der Druckempfindlichkeit:"
 
-#: prefs.js:93
+#: Settings.ui.h:7
 msgid "Pressure barrier's timeout:"
 msgstr "Time-Out der Druckempfindlichkeit:"
 
-#: prefs.js:129
+#: Settings.ui.h:8
+msgid "Sensitivity"
+msgstr "Empfindlichkeit"
+
+#: Settings.ui.h:9
 msgid "Slide animation time when entering/leaving overview:"
 msgstr "Animationszeit beim Betreten/Verlassen der Übersicht:"
 
-#: prefs.js:130
+#: Settings.ui.h:10
 msgid "Slide animation time when mouse approaches edge of the screen:"
 msgstr "Animationszeit, wenn die Maus den Bildschirmrand berührt:"
 
-#: prefs.js:221
-msgid "Key that triggers the bar to be shown:"
-msgstr "Taste um die Leiste anzuzeigen:"
+#: Settings.ui.h:11
+msgid "Animation"
+msgstr "Animation"
 
-#: prefs.js:241
+#: Settings.ui.h:12
+msgid "Key that triggers the bar to be shown:"
+msgstr "Taste, um die Leiste anzuzeigen:"
+
+#: Settings.ui.h:13
 msgid "Delay before the bar rehides after key press:"
 msgstr ""
-"Verzögerung, nachdem die Leiste nach dem Drücken der Taste, wieder "
-"ausgeblendet wird:"
+"Zeit, nach der die Leiste nach dem Drücken der Taste wieder ausgeblendet "
+"wird:"
 
-#: prefs.js:257
+#: Settings.ui.h:14
 msgid "Pressing the shortcut again rehides the panel"
-msgstr "Erneutes Drücken des Tastenkürzels versteckt die Leiste wieder."
+msgstr "Erneutes Drücken des Tastenkürzels versteckt die Leiste wieder"
+
+#: Settings.ui.h:15
+msgid "Keyboard shortcuts"
+msgstr "Tastaturkürzel"
+
+#: Settings.ui.h:16
+msgid "Only hide panel when a window takes the space"
+msgstr "Panel nur verstecken, wenn ein Fenster im Weg ist"
+
+#: Settings.ui.h:17
+msgid "Only when the active window takes the space"
+msgstr "Nur wenn das aktive Fenster im Weg ist"
+
+#: Settings.ui.h:18
+msgid "Intellihide"
+msgstr "Intelligentes Ausblenden"
+
+#: Settings.ui.h:1
+msgid "Show panel when mouse approaches top edge of the screen"
+msgstr "Panel anzeigen, wenn die Maus den oberen Bildschirmrand berührt"
+
+#~ msgid "In the above case, also show panel when fullscreen."
+#~ msgstr "In diesem Fall das Panel auch im Vollbildmodus anzeigen."
+
+#~ msgid "Pressure barrier's threshold."
+#~ msgstr "Schwellenwert der Druckempfindlichkeit."
+
+#~ msgid "Pressure barrier's timeout."
+#~ msgstr "Time-Out der Druckempfindlichkeit."
+
+#~ msgid "Slide animation time when entering/leaving overview."
+#~ msgstr "Animationszeit beim Betreten/Verlassen der Übersicht."
+
+#~ msgid "Slide animation time when mouse approaches edge of the screen."
+#~ msgstr "Animationszeit, wenn die Maus den Bildschirmrand berührt."
+
+#~ msgid "Key that triggers the bar to be shown."
+#~ msgstr "Taste, um die Leiste anzuzeigen."
+
+#~ msgid "Delay before the bar rehides after key press."
+#~ msgstr ""
+#~ "Zeit, nach der die Leiste nach dem Drücken der Taste wieder ausgeblendet "
+#~ "wird."
+
+#~ msgid "Pressing the shortcut again rehides the panel."
+#~ msgstr "Erneutes Drücken des Tastenkürzels versteckt die Leiste wieder."

--- a/locale/hidetopbar.pot
+++ b/locale/hidetopbar.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-27 20:17+0100\n"
+"POT-Creation-Date: 2021-09-14 11:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -87,4 +87,8 @@ msgstr ""
 
 #: Settings.ui.h:18
 msgid "Intellihide"
+msgstr ""
+
+#: Settings.ui.h:1
+msgid "Show panel when mouse approaches top edge of the screen"
 msgstr ""


### PR DESCRIPTION
I am a member of the German translation team over at [Damned Lies](https://l10n.gnome.org/teams/de/), GNOME's translation platform.
I checked the German translation and found some inconsistencies with our guidelines, so I fixed that - and I clarified that the mouse should approach the top panel in order for the panel to show up.
What do you think?