### PR TITLE
Fix error when disabling the extension

### DIFF
--- a/panelVisibilityManager.js
+++ b/panelVisibilityManager.js
@@ -420,6 +420,9 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
         } else {
           this._updateIntellihideStatus();
         }
+
+        this._bindTimeoutId = 0;
+        return false;
     }
 
     _bindSettingsChanges() {
@@ -464,7 +467,10 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
     }
 
     destroy() {
-        GLib.source_remove(this._bindTimeoutId);
+        if (this._bindTimeoutId) {
+            GLib.source_remove(this._bindTimeoutId);
+            this._bindTimeoutId = 0;
+        }
         this._intellihide.destroy();
         this._signalsHandler.destroy();
         Main.wm.removeKeybinding("shortcut-keybind");


### PR DESCRIPTION
When the extension is disabled, the log shows an error:

    Source ID XXXXX was not found when attempting to remove it

This is because that is the ID from a timeout, but when the extension is disabled, that timeout has already run and the source has been removed.

This MR fixes this error by setting to zero the ID after the timeout has been executed, and checking its value in the `destroy()` method. This ensures that the source is removed if the extension is enabled and disabled very quickly, while avoiding removing it when it doesn't exist anymore.