### PR TITLE
Add 42 since it works there too

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["3.38","40","41"],
+  "shell-version": ["3.38","40","41","42"],
   "uuid": "hidetopbar@mathieu.bidon.ca",
   "name": "Hide Top Bar",
   "settings-schema": "org.gnome.shell.extensions.hidetopbar",


### PR DESCRIPTION
Tested on Ubuntu Jammy Jellyfish + GNOME PPA with gnome-shell 42~alpha.

Preferences works too.

Thanks for this nice and useful extension.