### PR TITLE
Add support to keep the rounded corners when the panel is hidden

### DIFF
--- a/Settings-40.ui
+++ b/Settings-40.ui
@@ -45,7 +45,7 @@
     <property name="visible">True</property>
     <property name="can-focus">True</property>
     <child>
-      <!-- n-columns=2 n-rows=7 -->
+      <!-- n-columns=2 n-rows=8 -->
       <object class="GtkGrid">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
@@ -126,7 +126,7 @@
             <property name="can-focus">False</property>
             <property name="halign">start</property>
             <property name="hexpand">True</property>
-            <property name="label" translatable="yes">Pressure barrier's threshold:</property>
+            <property name="label" translatable="yes">Keep round corners when top bar is hidden</property>
             <layout>
               <property name="column">0</property>
               <property name="row">5</property>
@@ -139,10 +139,23 @@
             <property name="can-focus">False</property>
             <property name="halign">start</property>
             <property name="hexpand">True</property>
-            <property name="label" translatable="yes">Pressure barrier's timeout:</property>
+            <property name="label" translatable="yes">Pressure barrier's threshold:</property>
             <layout>
               <property name="column">0</property>
               <property name="row">6</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">start</property>
+            <property name="hexpand">True</property>
+            <property name="label" translatable="yes">Pressure barrier's timeout:</property>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">7</property>
             </layout>
           </object>
         </child>
@@ -208,6 +221,18 @@
           </object>
         </child>
         <child>
+          <object class="GtkSwitch" id="toggle_keep_round_corners">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <layout>
+              <property name="column">1</property>
+              <property name="row">5</property>
+            </layout>
+          </object>
+        </child>
+        <child>
           <object class="GtkSpinButton" id="spin_pressure_threshold">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
@@ -216,7 +241,7 @@
             <property name="adjustment">adjust_pressure_threshold</property>
             <layout>
               <property name="column">1</property>
-              <property name="row">5</property>
+              <property name="row">6</property>
             </layout>
           </object>
         </child>
@@ -229,7 +254,7 @@
             <property name="adjustment">adjust_pressure_timeout</property>
             <layout>
               <property name="column">1</property>
-              <property name="row">6</property>
+              <property name="row">7</property>
             </layout>
           </object>
         </child>

--- a/Settings.ui
+++ b/Settings.ui
@@ -45,7 +45,7 @@
     <property name="visible">True</property>
     <property name="can-focus">True</property>
     <child>
-      <!-- n-columns=2 n-rows=7 -->
+      <!-- n-columns=2 n-rows=8 -->
       <object class="GtkGrid">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
@@ -126,7 +126,7 @@
             <property name="can-focus">False</property>
             <property name="halign">start</property>
             <property name="hexpand">True</property>
-            <property name="label" translatable="yes">Pressure barrier's threshold:</property>
+            <property name="label" translatable="yes">Keep round corners when top bar is hidden</property>
           </object>
           <packing>
             <property name="left-attach">0</property>
@@ -139,11 +139,24 @@
             <property name="can-focus">False</property>
             <property name="halign">start</property>
             <property name="hexpand">True</property>
-            <property name="label" translatable="yes">Pressure barrier's timeout:</property>
+            <property name="label" translatable="yes">Pressure barrier's threshold:</property>
           </object>
           <packing>
             <property name="left-attach">0</property>
             <property name="top-attach">6</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">start</property>
+            <property name="hexpand">True</property>
+            <property name="label" translatable="yes">Pressure barrier's timeout:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">7</property>
           </packing>
         </child>
         <child>
@@ -208,6 +221,18 @@
           </packing>
         </child>
         <child>
+          <object class="GtkSwitch" id="toggle_keep_round_corners">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">5</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkSpinButton" id="spin_pressure_threshold">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
@@ -217,7 +242,7 @@
           </object>
           <packing>
             <property name="left-attach">1</property>
-            <property name="top-attach">5</property>
+            <property name="top-attach">6</property>
           </packing>
         </child>
         <child>
@@ -230,7 +255,7 @@
           </object>
           <packing>
             <property name="left-attach">1</property>
-            <property name="top-attach">6</property>
+            <property name="top-attach">7</property>
           </packing>
         </child>
       </object>

--- a/panelVisibilityManager.js
+++ b/panelVisibilityManager.js
@@ -103,7 +103,8 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
             mode: Clutter.AnimationMode.EASE_OUT_QUAD,
             onComplete: () => {
                 this._animationActive = false;
-                if (!self._settings.get_boolean('keep-round-corners')) {
+                print("Round corners " + this._settings.get_boolean('keep-round-corners'));
+                if (!this._settings.get_boolean('keep-round-corners')) {
                     PanelBox.hide();
                 }
                 this._updateHotCorner(true);

--- a/panelVisibilityManager.js
+++ b/panelVisibilityManager.js
@@ -103,7 +103,9 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
             mode: Clutter.AnimationMode.EASE_OUT_QUAD,
             onComplete: () => {
                 this._animationActive = false;
-                PanelBox.hide();
+                if (!self._settings.get_boolean('keep-round-corners')) {
+                    PanelBox.hide();
+                }
                 this._updateHotCorner(true);
             }
         });

--- a/panelVisibilityManager.js
+++ b/panelVisibilityManager.js
@@ -103,7 +103,6 @@ var PanelVisibilityManager = class HideTopBar_PanelVisibilityManager {
             mode: Clutter.AnimationMode.EASE_OUT_QUAD,
             onComplete: () => {
                 this._animationActive = false;
-                print("Round corners " + this._settings.get_boolean('keep-round-corners'));
                 if (!this._settings.get_boolean('keep-round-corners')) {
                     PanelBox.hide();
                 }

--- a/prefs.js
+++ b/prefs.js
@@ -58,7 +58,8 @@ function buildPrefsWidget() {
      'mouse-sensitive-fullscreen-window',
      'show-in-overview',
      'hot-corner',
-     'mouse-triggers-overview'
+     'mouse-triggers-overview',
+     'keep-round-corners'
     ].forEach(function (s) {
         let settings_onoff = builder.get_object("toggle_" + s.replace(/-/g, "_"));
         settings_onoff.set_active(settings.get_boolean(s));

--- a/schemas/org.gnome.shell.extensions.hidetopbar.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.hidetopbar.gschema.xml
@@ -37,7 +37,7 @@
       <default>false</default>
       <summary>Keep round corners on the top</summary>
       <description>
-        Set to "true" to keep round corners on the top even when the panel is hidden.
+        Set to "true" to keep the round corners on the top even when the panel is hidden.
       </description>
     </key>
     <key name="animation-time-overview" type="d">

--- a/schemas/org.gnome.shell.extensions.hidetopbar.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.hidetopbar.gschema.xml
@@ -33,6 +33,13 @@
         the edge of the screen.
       </description>
     </key>
+    <key name="keep-round-corners" type="b">
+      <default>false</default>
+      <summary>Keep round corners on the top</summary>
+      <description>
+        Set to "true" to keep round corners on the top even when the panel is hidden.
+      </description>
+    </key>
     <key name="animation-time-overview" type="d">
       <default>0.4</default>
       <summary>Slide in/out animation time</summary>


### PR DESCRIPTION
I added a switch in the settings to turn on or off the keep round corners feature, with an if statement to check weather to execute `PanelBox.hide` or not. Here is the effect when it's turned on:

![image](https://user-images.githubusercontent.com/68882116/159556269-82f32d9e-41a0-4222-b905-32bb565e9880.png)

![image](https://user-images.githubusercontent.com/68882116/159554510-87f82816-b898-4358-9f17-8cb466f6054c.png)

This change requires changing the `schemas` folder, which is in `.gitignore`. I kept the original `.gitignore`